### PR TITLE
Break for loop in NetworkServerApp::addPktToProcessingTable if found

### DIFF
--- a/src/LoRa/NetworkServerApp.cc
+++ b/src/LoRa/NetworkServerApp.cc
@@ -204,6 +204,7 @@ void NetworkServerApp::addPktToProcessingTable(LoRaMacFrame* pkt)
             packetExists = true;
             receivedPackets[i].possibleGateways.emplace_back(cInfo->getSrcAddr(), math::fraction2dB(pkt->getSNIR()), pkt->getRSSI());
             delete pkt;
+            break;
         }
     }
     if(packetExists == false)


### PR DESCRIPTION
The NetworkServerApp::addPktToProcessingTable() function loops through
the receivedPackets vector to determine whether the newly received pkt
is a new packet or a duplicate of a previous one. If it's a duplicate,
most of the times the first occurrence will be in the last position of
receivedPackets. However, under certain heavy load conditions,
duplicates of different packets may arrive interlaced and the original
packet will be found before the last position in receivedPackets; pkt
will be deleted but the for loop will continue and crash (since
pkt->getTransmitterAddress() won't exist anymore).

Breaking the loop after deleting pkt fixes the problem.

Signed-off-by: Roger Pueyo Centelles <rpueyo@ac.upc.edu>